### PR TITLE
Fix errors during Python package generation

### DIFF
--- a/.github/workflows/test_install.yaml
+++ b/.github/workflows/test_install.yaml
@@ -1,0 +1,21 @@
+name: Test Install
+on: [push]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Install Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: '3.9'
+            - name: Install Cython
+              run: pip install cython
+            - name: Create Package
+              run: python3 make_cython.py
+            - name: Build and Install
+              run: |
+                  cd cython
+                  python3 setup.py build_ext
+                  python3 setup.py install

--- a/make_cython.py
+++ b/make_cython.py
@@ -40,7 +40,8 @@ def find_func(name, c_file):
     name = re.escape(name)
     m = re.search(r'\n.+\s' + name + r'\s*\(.+\)\s*\{', contents)
     if m:
-        return re.sub(r'\)\s*\{$', ')', m.group(0)).strip()
+        m = re.sub(r'\)\s*\{$', ')', m.group(0)).strip()
+        return re.sub(r'\/\*[\w\d -]*\*\/', '', m)
 
 def alias_func(func):
     return re.sub(r'^([a-zA-Z0-9_]+)\s+([a-zA-Z0-9_]+)', r'\1 c_\2 "\2" ', func)
@@ -103,6 +104,7 @@ def main():
 
             with open(pyxfile, 'w') as pyx:
                 pyx.write(f'# from {path.relative_to(root)}\n')
+                pyx.write('# cython: language_level=3\n')
                 pyx.write('from libc.stdint cimport *\n')
                 pyx.write('\n')
                 pyx.write('cdef extern:\n')


### PR DESCRIPTION
This fixes:
- Cython warnings due to missing `language_level` directives
- Errors in module compilation due to inline comments in some C files

Closes #2 

It also adds a CI script that performs the Python package generation and install automatically.

